### PR TITLE
Adds a configurable path string option of llvm-header-guard.RfindString

### DIFF
--- a/clang-tidy/llvm/HeaderGuardCheck.cpp
+++ b/clang-tidy/llvm/HeaderGuardCheck.cpp
@@ -15,7 +15,12 @@ namespace llvm {
 
 LLVMHeaderGuardCheck::LLVMHeaderGuardCheck(StringRef Name,
                                            ClangTidyContext *Context)
-    : HeaderGuardCheck(Name, Context) {}
+    : HeaderGuardCheck(Name, Context),
+      RfindString(Options.get("RfindString", "")) {}
+
+void LLVMHeaderGuardCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "RfindString", RfindString);
+}
 
 std::string LLVMHeaderGuardCheck::getHeaderGuard(StringRef Filename,
                                                  StringRef OldGuard) {
@@ -28,6 +33,11 @@ std::string LLVMHeaderGuardCheck::getHeaderGuard(StringRef Filename,
   size_t PosInclude = Guard.rfind("include/");
   if (PosInclude != StringRef::npos)
     Guard = Guard.substr(PosInclude + std::strlen("include/"));
+  else if (!RfindString.empty()) {
+    PosInclude = Guard.rfind(RfindString);
+    if (PosInclude != StringRef::npos)
+      Guard = Guard.substr(PosInclude);
+  }
 
   // For clang we drop the _TOOLS_.
   size_t PosToolsClang = Guard.rfind("tools/clang/");

--- a/clang-tidy/llvm/HeaderGuardCheck.h
+++ b/clang-tidy/llvm/HeaderGuardCheck.h
@@ -31,6 +31,11 @@ public:
 
   bool shouldSuggestEndifComment(StringRef Filename) override { return false; }
   std::string getHeaderGuard(StringRef Filename, StringRef OldGuard) override;
+
+private:
+  void storeOptions(ClangTidyOptions::OptionMap &Options) override;
+
+  const std::string RfindString;
 };
 
 } // namespace llvm


### PR DESCRIPTION
Shoehorns functionality I needed into an existing clang-tidy check.

Adds an option of `RfindString`. This can be set in a `.clang-tidy` file to a path component from which include files should be considered to be rooted from. The code first reverse looks for the LLVM expected path of `include/` and expects include files to be rooted under it, or failing that, reverse looks for the configured `RfindString` path and expects include files to be rooted from that, or then fallback to warning about the header guard's name.